### PR TITLE
30 - Terraform the ECR to host the image of the pipeline

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,7 +2,20 @@
 
 Create a `terraform.tfvars` file locally, and populate it with:
 
-- PLACEHOLDER_KEY - {DESCRIPTION OF VALUE}
-- ...
+- AWS_ACCESS_KEY - AWS IAM access key
+- AWS_SECRET_KEY - The corresponding secret key for the above IAM user
 
 Note: `terraform init` has been run.
+
+## Resources provisioned
+
+`main.tf` will provision the following resources:
+
+- An ECR Repository for the image for the ETL pipeline: `c17-allum-ecr-pipeline-terraform`
+
+## Provisioning Resources
+
+To provision resources run the following commands:
+
+`terraform plan`
+`terraform apply`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,4 +5,4 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - PLACEHOLDER_KEY - {DESCRIPTION OF VALUE}
 - ...
 
-Note: `terraform init` has not been run yet.
+Note: `terraform init` has been run.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+    region = var.AWS_REGION
+    access_key = var.AWS_ACCESS_KEY
+    secret_key = var.AWS_SECRET_KEY
+}
+
+resource "aws_ecr_repository" "pipeline-lambda-repo" {
+    name = "c17-allum-ecr-pipeline-terraform"
+    image_tag_mutability = "MUTABLE"
+
+    encryption_configuration {
+        encryption_type = "AES256"
+    }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,12 @@
+variable AWS_REGION {
+    type = string
+    default = "eu-west-2"
+}
+
+variable AWS_ACCESS_KEY {
+    type = string
+}
+
+variable AWS_SECRET_KEY {
+    type = string
+}


### PR DESCRIPTION
Added to `/terraform/main.tf` and `variables.tf`
Updated `/terraform/README.md`

- Defined a provider in `main.tf`
- Provisioned an ECR repo for the pipeline image in `main.tf`
- Added region and access key variables in `variables.tf`
- Created a local (not pushed) `terraform.tfvars` - If you want to terraform apply, please ask me and I'll send over the file. I'm not sure if anything breaks if we apply using different credentials.
- Updated the README to describe the changes.

Closes #30.