### PR TITLE
27 - Append data to csv

### DIFF
--- a/pipeline_live_data/extract.py
+++ b/pipeline_live_data/extract.py
@@ -9,6 +9,9 @@ import aiohttp
 
 BASE_URL = 'https://sigma-labs-bot.herokuapp.com/api/plants/'
 CSV_NAME = 'raw_plants.csv'
+FIELD_NAMES = ['plant_id', 'name', 'error', 'temperature', 'soil_moisture', 'last_watered',
+               'recording_taken', 'received_at', 'scientific_name', 'botanist',
+               'origin_location', 'images']
 
 
 async def extract_plant_data() -> list[dict]:
@@ -17,7 +20,6 @@ async def extract_plant_data() -> list[dict]:
     async with aiohttp.ClientSession() as session:  # Running all the time
 
         plants = [extract_single_plant_data(i, session) for i in range(51)]
-
         plant_data = await asyncio.gather(*plants)
 
     print("Finished all plants")
@@ -38,28 +40,22 @@ async def extract_single_plant_data(plant_id: int, session: aiohttp.ClientSessio
 
     print("Status:", response.status)
     print(f"Finished plant {plant_id}.")
-
     return html
 
 
 def create_plants_csv(plants: list[dict]) -> None:
     """Create a csv from the extracted plants data."""
 
-    fieldnames = set()
-    for entry in plants:
-        fieldnames.update(entry.keys())
-    fieldnames = list(fieldnames)
-
     with open(CSV_NAME, mode='a', newline='', encoding='utf-8') as file:
-        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer = csv.DictWriter(file, fieldnames=FIELD_NAMES)
 
-        if not os.path.exists(CSV_NAME):
+        if not os.path.exists(CSV_NAME) or os.path.getsize(CSV_NAME) == 0:
             writer.writeheader()
 
         writer.writerows(plants)
 
 
 if __name__ == "__main__":
-    plants_data = asyncio.run(extract_plant_data())
 
+    plants_data = asyncio.run(extract_plant_data())
     create_plants_csv(plants_data)

--- a/pipeline_live_data/extract.py
+++ b/pipeline_live_data/extract.py
@@ -1,5 +1,6 @@
 """Extracting plant data from the API."""
 
+import os
 import csv
 import asyncio
 from datetime import datetime, timezone
@@ -49,9 +50,12 @@ def create_plants_csv(plants: list[dict]) -> None:
         fieldnames.update(entry.keys())
     fieldnames = list(fieldnames)
 
-    with open(CSV_NAME, mode='w', newline='', encoding='utf-8') as file:
+    with open(CSV_NAME, mode='a', newline='', encoding='utf-8') as file:
         writer = csv.DictWriter(file, fieldnames=fieldnames)
-        writer.writeheader()
+
+        if not os.path.exists(CSV_NAME):
+            writer.writeheader()
+
         writer.writerows(plants)
 
 


### PR DESCRIPTION
Editing the `/pipeline_live_data/extract.py` script to append to the CSV.

- Now checks if a CSV exists that isn't empty already
- If not, writes the headers
- Otherwise appends new data
- Fixed bug with column headers being unordered by explicitly defining FIELD_NAMES
  - Note: This fix could be improved