### PR TITLE
29 - Terraform the Lambda to run the image of the pipeline

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,7 +11,21 @@ Note: `terraform init` has been run.
 
 `main.tf` will provision the following resources:
 
-- An ECR Repository for the image for the ETL pipeline: `c17-allum-ecr-pipeline-terraform`
+#### An ECR Repository for the image for the ETL pipeline: 
+- `c17-allum-ecr-pipeline-terraform`
+
+#### IAM Role & Policies for the pipeline Lambda function:
+- Permissions for CloudWatch Logs
+
+#### Lambda Function for ETL pipeline
+- `c17-allum-lambda-pipeline-terraform`
+- Runs the ETL Pipeline every minute.
+- Triggered by an EventBridge.
+- Runs the latest image from `c17-allum-ecr-pipeline-terraform`.
+
+## To Do
+
+- Add environment variables to the lambda resource once known.
 
 ## Provisioning Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,11 +4,76 @@ provider "aws" {
     secret_key = var.AWS_SECRET_KEY
 }
 
-resource "aws_ecr_repository" "pipeline-lambda-repo" {
+
+# ECR Repository for pipeline image
+
+resource "aws_ecr_repository" "pipeline-lambda-image-repo" {
     name = "c17-allum-ecr-pipeline-terraform"
     image_tag_mutability = "MUTABLE"
 
     encryption_configuration {
         encryption_type = "AES256"
     }
+}
+
+# Image for lambda to run
+
+data "aws_ecr_image" "pipeline-lambda-image-version" {
+  repository_name = aws_ecr_repository.pipeline-lambda-image-repo.name
+  image_tag       = "latest"
+}
+
+# Permissions for lambda
+
+data "aws_iam_policy_document" "pipeline-lambda-role-trust-policy-doc" {
+    statement {
+      effect = "Allow"
+      principals {
+        type = "Service"
+        identifiers = [ "lambda.amazonaws.com" ]
+      }
+      actions = [
+        "sts:AssumeRole"
+      ]
+    }
+}
+
+data "aws_iam_policy_document" "pipeline-lambda-role-permissions-policy-doc" {
+    statement {
+      effect = "Allow"
+      actions = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      resources = [ "arn:aws:logs:eu-west-2:129033205317:*" ]
+    }
+}
+
+resource "aws_iam_role" "pipeline-lambda-role" {
+    name = "c17-allum-lambda-pipeline-terraform-role"
+    assume_role_policy = data.aws_iam_policy_document.pipeline-lambda-role-trust-policy-doc.json
+}
+
+resource "aws_iam_policy" "pipeline-lambda-role-permissions-policy" {
+    name = "c17-allum-lambda-pipeline-permissions-policy"
+    policy = data.aws_iam_policy_document.pipeline-lambda-role-permissions-policy-doc.json
+}
+
+
+resource "aws_iam_role_policy_attachment" "pipeline-lambda-role-policy-connection" {
+  role = aws_iam_role.pipeline-lambda-role.name
+  policy_arn = aws_iam_policy.pipeline-lambda-role-permissions-policy.arn
+}
+
+# Lambda
+# TODO: add environment variables
+
+resource "aws_lambda_function" "pipeline-lambda" {
+  function_name = "c17-allum-lambda-pipeline-terraform"
+  description = "Runs the ETL Pipeline every minute. Triggered by an EventBridge."
+  role = aws_iam_role.pipeline-lambda-role.arn
+  package_type = "Image"
+  image_uri = data.aws_ecr_image.pipeline-lambda-image-version.image_uri
+  timeout = 900
 }


### PR DESCRIPTION
Added to `/terraform/main.tf`
Updated `/terraform/README.md`

- Added IAM Role & Policies for the pipeline Lambda function.
- Added Lambda Function for ETL pipeline.
- Updated the README to describe the changes.
- TODO: add environment variables to the lambda once known.

I also changed the style of the README, would someone be able to give me feedback if it looks better/worse? I'm open to any suggestions to improve the layout as I'm not great with markdown.

Also TODO for the Lambda, we can pass it the environment variables we use in the ETL scripts, such as the DB credentials for the RDS. It's a quick edit to the lambda resource once we know what we need!

Closes #29.