### PR TITLE
35 - Begin transform of data

### DIFF
--- a/pipeline_live_data/README.md
+++ b/pipeline_live_data/README.md
@@ -2,9 +2,20 @@
 
 TEMPORARY DEV LOG:
 List of columns dropped:
-- images
-- scientific_name
+- 'images'
+- 'botanist'
+- 'origin_location'
 
 List of columns renamed:
 - 'name' -> 'plant_name'
 - 'error' -> 'error_name'
+- 'recording_taken' -> 'at'
+
+List of new columns:
+- 'botanist_name'
+- 'botanist_email'
+- 'botanist_phone'
+- 'origin_latitude'
+- 'origin_longitude'
+- 'city_name'
+- 'country_name'

--- a/pipeline_live_data/README.md
+++ b/pipeline_live_data/README.md
@@ -1,2 +1,10 @@
 # `/pipeline_live_data`
 
+TEMPORARY DEV LOG:
+List of columns dropped:
+- images
+- scientific_name
+
+List of columns renamed:
+- 'name' -> 'plant_name'
+- 'error' -> 'error_name'

--- a/pipeline_live_data/requirements.txt
+++ b/pipeline_live_data/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pylint
 aiohttp
+pandas

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -1,4 +1,78 @@
 """Transforming the extracted data."""
 
+import ast
+import pandas as pd
+
+from extract import CSV_NAME
+
+
+def get_df_from_csv(filename: str) -> pd.DataFrame:
+    """Returns a dataframe from the csv data."""
+    return pd.read_csv(filename)
+
+
+def replace_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop and rename columns in a given dataframe."""
+
+    df = df.drop(columns=['images', 'scientific_name'])
+    df = df.rename(columns={
+        'name': 'plant_name',
+        'error': 'error_name'
+    })
+    return df
+
+
+def fix_type_of_string_dicts(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """Changes the type of dict-like like strings to dicts."""
+
+    for col in cols:
+        df[col] = df[col].apply(
+            lambda x: ast.literal_eval(x) if isinstance(x, str) else None)
+
+    return df
+
+
+def create_columns_from_dict_strings(orig_df: pd.DataFrame,
+                                     new_df: pd.DataFrame, lookup_map: list[tuple]) -> pd.DataFrame:
+    """
+    Returns a dataframe with new columns, extracted from a
+    dict in the original dataframe.
+    Requires a list of tuples, with the tuples ordered as:
+      (name_new_column, name_old_column, name_old_column_key).
+    """
+
+    for item in lookup_map:
+        # log here, mapping item[0] ..
+
+        new_df[item[0]] = orig_df[item[1]].apply(
+            lambda x: x.get(item[2]) if isinstance(x, dict) else None
+        )
+    return new_df
+
+
 if __name__ == "__main__":
-    pass
+
+    df = get_df_from_csv(CSV_NAME)
+
+    df = replace_columns(df)
+    df = fix_type_of_string_dicts(df, ['botanist', 'origin_location'])
+
+    clean_df = df[['plant_id', 'plant_name', 'error_name', 'temperature',
+                   'soil_moisture', 'last_watered', 'recording_taken', 'received_at']].copy()
+
+    # clean_df['botanist_name'] = df['botanist'].apply(
+    #     lambda x: x.get('name') if isinstance(x, dict) else None)
+
+    # clean_df['botanist_email'] = df['botanist'].apply(
+    #     lambda x: x.get('email') if isinstance(x, dict) else None)
+
+    # clean_df['origin_latitude'] = df['origin_location'].apply(
+    #     lambda x: x.get('latitude') if isinstance(x, dict) else None)
+
+    clean_df = create_columns_from_dict_strings(df, clean_df, [(
+        'botanist_name', 'botanist', 'name'), ('botanist_email', 'botanist', 'email')])
+
+    print(df.info())
+    print(clean_df.info())
+    print(clean_df['botanist_name'].head(10))
+    print(clean_df['botanist_email'].head(10))

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -25,7 +25,7 @@ def replace_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def fix_type_of_string_dicts(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
-    """Changes the type of dict-like like strings to dicts."""
+    """Changes the type of dict-like strings to dicts."""
 
     for col in cols:
         df[col] = df[col].apply(

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -1,6 +1,7 @@
 """Transforming the extracted data."""
 
 import ast
+
 import pandas as pd
 
 from extract import CSV_NAME

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -14,7 +14,7 @@ def get_df_from_csv(filename: str) -> pd.DataFrame:
 def replace_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Drop and rename columns in a given dataframe."""
 
-    df = df.drop(columns=['images', 'scientific_name'])
+    df = df.drop(columns=['images'])
     df = df.rename(columns={
         'name': 'plant_name',
         'error': 'error_name'
@@ -50,29 +50,32 @@ def create_columns_from_dict_strings(orig_df: pd.DataFrame,
     return new_df
 
 
-if __name__ == "__main__":
+def main_transform() -> pd.DataFrame:
+    """Returns a clean and processed dataframe."""
 
     df = get_df_from_csv(CSV_NAME)
 
     df = replace_columns(df)
     df = fix_type_of_string_dicts(df, ['botanist', 'origin_location'])
 
-    clean_df = df[['plant_id', 'plant_name', 'error_name', 'temperature',
+    clean_df = df[['plant_id', 'plant_name', 'scientific_name', 'error_name', 'temperature',
                    'soil_moisture', 'last_watered', 'recording_taken', 'received_at']].copy()
 
-    # clean_df['botanist_name'] = df['botanist'].apply(
-    #     lambda x: x.get('name') if isinstance(x, dict) else None)
+    clean_df = create_columns_from_dict_strings(df, clean_df, [
+        ('botanist_name', 'botanist', 'name'),
+        ('botanist_email', 'botanist', 'email'),
+        ('botanist_phone', 'botanist', 'phone'),
+        ('origin_latitude', 'origin_location', 'latitude'),
+        ('origin_longitude', 'origin_location', 'longitude'),
+        ('city_name', 'origin_location', 'city'),
+        ('country_name', 'origin_location', 'country')
+    ])
 
-    # clean_df['botanist_email'] = df['botanist'].apply(
-    #     lambda x: x.get('email') if isinstance(x, dict) else None)
+    return clean_df
 
-    # clean_df['origin_latitude'] = df['origin_location'].apply(
-    #     lambda x: x.get('latitude') if isinstance(x, dict) else None)
 
-    clean_df = create_columns_from_dict_strings(df, clean_df, [(
-        'botanist_name', 'botanist', 'name'), ('botanist_email', 'botanist', 'email')])
+if __name__ == "__main__":
 
-    print(df.info())
-    print(clean_df.info())
-    print(clean_df['botanist_name'].head(10))
-    print(clean_df['botanist_email'].head(10))
+    cleaned = main_transform()
+
+    print(cleaned.info())

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -51,6 +51,14 @@ def create_columns_from_dict_strings(orig_df: pd.DataFrame,
     return new_df
 
 
+def create_timestamps(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """Returns a dataframe with columns converted to timestamps."""
+
+    for col in cols:
+        df[col] = pd.to_datetime(df[col], utc=True)
+    return df
+
+
 def main_transform() -> pd.DataFrame:
     """Returns a clean and processed dataframe."""
 
@@ -74,6 +82,7 @@ def main_transform() -> pd.DataFrame:
         ('country_name', 'origin_location', 'country')
     ])
 
+    clean_df = create_timestamps(clean_df, ['at', 'received_at'])
     return clean_df
 
 
@@ -82,5 +91,5 @@ if __name__ == "__main__":
     cleaned = main_transform()
 
     print(cleaned.info())
-    print(cleaned['scientific_name'].head(50))
+    print(cleaned['received_at'].head(50))
     print(cleaned.head(10))

--- a/pipeline_live_data/transform.py
+++ b/pipeline_live_data/transform.py
@@ -17,7 +17,8 @@ def replace_columns(df: pd.DataFrame) -> pd.DataFrame:
     df = df.drop(columns=['images'])
     df = df.rename(columns={
         'name': 'plant_name',
-        'error': 'error_name'
+        'error': 'error_name',
+        'recording_taken': 'at'
     })
     return df
 
@@ -57,9 +58,11 @@ def main_transform() -> pd.DataFrame:
 
     df = replace_columns(df)
     df = fix_type_of_string_dicts(df, ['botanist', 'origin_location'])
+    df['scientific_name'] = df['scientific_name'].str.strip(
+        '[]').str.strip("'").str.strip('"')
 
     clean_df = df[['plant_id', 'plant_name', 'scientific_name', 'error_name', 'temperature',
-                   'soil_moisture', 'last_watered', 'recording_taken', 'received_at']].copy()
+                   'soil_moisture', 'last_watered', 'at', 'received_at']].copy()
 
     clean_df = create_columns_from_dict_strings(df, clean_df, [
         ('botanist_name', 'botanist', 'name'),
@@ -79,3 +82,5 @@ if __name__ == "__main__":
     cleaned = main_transform()
 
     print(cleaned.info())
+    print(cleaned['scientific_name'].head(50))
+    print(cleaned.head(10))


### PR DESCRIPTION
Updates to the `/pipeline_live_data/transform.py` script. Changes include:

- Getting a Pandas dataframe from a csv
- Dropping the images column
- Renaming the name, error and recording_taken columns
- Fixing the type inside the origin_location and botanist columns (string-like dict -> dict)
- Creating new columns from those (matching the ERD)
- Change at and received_at to be of type datetime

It's a W.I.P, but worth updating on the progress and perhaps having this version testable to others. The only significant change now would be dealing with 'NaN' and 'NaT' values, mostly present when there is an 'error'.