### PR TITLE
69 - Terraform Lambda and S3 bucket for the archived data pipeline.

### DIFF
--- a/terraform/ECR/README.md
+++ b/terraform/ECR/README.md
@@ -19,6 +19,10 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - `c17-allum-ecr-dashboard-terraform`.
 - Stores the container image for the Streamlit dashboard.
 
+#### ECR Repository:
+- `c17-allum-ecr-archived-terraform`.
+- Stores the container image for the archived data Lambda.
+
 ## Provisioning Resources
 
 To provision resources run the following commands:

--- a/terraform/ECR/ecr.tf
+++ b/terraform/ECR/ecr.tf
@@ -25,3 +25,14 @@ resource "aws_ecr_repository" "dashboard-td-image-repo" {
     encryption_type = "AES256"
   }
 }
+
+# ECR Repository for archived data image
+
+resource "aws_ecr_repository" "archived-lambda-image-repo" {
+  name                 = "c17-allum-ecr-archived-terraform"
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}

--- a/terraform/pipeline_archived_data/README.md
+++ b/terraform/pipeline_archived_data/README.md
@@ -13,12 +13,22 @@ Create a `terraform.tfvars` file locally, and populate it with:
 
 #### IAM Role & Policies:
 - Permissions for CloudWatch Logs.
+- Permissions for Lambda to write to S3.
 
 #### Lambda Function:
 - `c17-allum-lambda-archived-terraform`.
 - Retrieves oldest one hour of data and removes it from the database before uploading to S3.
 - Scheduled to run every hour via EventBridge.
 - Runs the latest image from `c17-allum-ecr-archived-terraform`.
+
+#### S3 Bucket:
+- `c17-allum-s3-archived-data`.
+- Stores archived data.
+
+## To Do
+
+- Add environment variables to the lambda resource once known.
+- Lambda may need `vpc_config` block to access RDS.
 
 ## Provisioning Resources
 

--- a/terraform/pipeline_archived_data/README.md
+++ b/terraform/pipeline_archived_data/README.md
@@ -11,6 +11,14 @@ Create a `terraform.tfvars` file locally, and populate it with:
 
 ## Resources provisioned
 
+#### IAM Role & Policies:
+- Permissions for CloudWatch Logs.
+
+#### Lambda Function:
+- `c17-allum-lambda-archived-terraform`.
+- Retrieves oldest one hour of data and removes it from the database before uploading to S3.
+- Scheduled to run every hour via EventBridge.
+- Runs the latest image from `c17-allum-ecr-archived-terraform`.
 
 ## Provisioning Resources
 

--- a/terraform/pipeline_archived_data/README.md
+++ b/terraform/pipeline_archived_data/README.md
@@ -29,6 +29,7 @@ Create a `terraform.tfvars` file locally, and populate it with:
 
 - Add environment variables to the lambda resource once known.
 - Lambda may need `vpc_config` block to access RDS.
+- S3 may need `aws_s3_bucket_policy` resource to allow lambda write access.
 
 ## Provisioning Resources
 

--- a/terraform/pipeline_archived_data/pipeline_archived.tf
+++ b/terraform/pipeline_archived_data/pipeline_archived.tf
@@ -4,7 +4,7 @@ provider "aws" {
   secret_key = var.SECRET_KEY
 }
 
-# ECR Repository for pipeline image
+# ECR Repository for archived data image
 
 data "aws_ecr_repository" "archived-lambda-image-repo" {
   name = "c17-allum-ecr-archived-terraform"
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy_attachment" "archived-lambda-role-policy-connectio
 # Lambda
 # TODO: add environment variables
 
-resource "aws_lambda_function" "pipeline-lambda" {
+resource "aws_lambda_function" "archived-lambda" {
   function_name = "c17-allum-lambda-archived-terraform"
   description   = "Retrieves oldest one hour of data and removes it from the database before uploading to S3. Triggered by an EventBridge."
   role          = aws_iam_role.archived-lambda-role.arn
@@ -73,4 +73,3 @@ resource "aws_lambda_function" "pipeline-lambda" {
 }
 
 # S3 Bucket
-

--- a/terraform/pipeline_archived_data/pipeline_archived.tf
+++ b/terraform/pipeline_archived_data/pipeline_archived.tf
@@ -3,3 +3,74 @@ provider "aws" {
   access_key = var.ACCESS_KEY
   secret_key = var.SECRET_KEY
 }
+
+# ECR Repository for pipeline image
+
+data "aws_ecr_repository" "archived-lambda-image-repo" {
+  name = "c17-allum-ecr-archived-terraform"
+}
+
+# Image for lambda to run
+
+data "aws_ecr_image" "archived-lambda-image-version" {
+  repository_name = data.aws_ecr_repository.archived-lambda-image-repo.name
+  image_tag       = "latest"
+}
+
+# Permissions for lambda
+
+data "aws_iam_policy_document" "archived-lambda-role-trust-policy-doc" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "archived-lambda-role-permissions-policy-doc" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["arn:aws:logs:eu-west-2:129033205317:*"]
+  }
+}
+
+resource "aws_iam_role" "archived-lambda-role" {
+  name               = "c17-allum-lambda-archived-terraform-role"
+  assume_role_policy = data.aws_iam_policy_document.archived-lambda-role-trust-policy-doc.json
+}
+
+resource "aws_iam_policy" "archived-lambda-role-permissions-policy" {
+  name   = "c17-allum-lambda-archived-permissions-policy"
+  policy = data.aws_iam_policy_document.archived-lambda-role-permissions-policy-doc.json
+}
+
+
+resource "aws_iam_role_policy_attachment" "archived-lambda-role-policy-connection" {
+  role       = aws_iam_role.archived-lambda-role.name
+  policy_arn = aws_iam_policy.archived-lambda-role-permissions-policy.arn
+}
+
+# Lambda
+# TODO: add environment variables
+
+resource "aws_lambda_function" "pipeline-lambda" {
+  function_name = "c17-allum-lambda-archived-terraform"
+  description   = "Retrieves oldest one hour of data and removes it from the database before uploading to S3. Triggered by an EventBridge."
+  role          = aws_iam_role.archived-lambda-role.arn
+  package_type  = "Image"
+  image_uri     = data.aws_ecr_image.archived-lambda-image-version.image_uri
+  timeout       = 900
+}
+
+# S3 Bucket
+

--- a/terraform/pipeline_archived_data/pipeline_archived.tf
+++ b/terraform/pipeline_archived_data/pipeline_archived.tf
@@ -42,6 +42,14 @@ data "aws_iam_policy_document" "archived-lambda-role-permissions-policy-doc" {
     ]
     resources = ["arn:aws:logs:eu-west-2:129033205317:*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = ["${aws_s3_bucket.archived-s3.arn}/*"]
+  }
 }
 
 resource "aws_iam_role" "archived-lambda-role" {
@@ -73,3 +81,7 @@ resource "aws_lambda_function" "archived-lambda" {
 }
 
 # S3 Bucket
+
+resource "aws_s3_bucket" "archived-s3" {
+  bucket = "c17-allum-s3-archived-data"
+}

--- a/terraform/pipeline_live_data/README.md
+++ b/terraform/pipeline_live_data/README.md
@@ -23,6 +23,7 @@ Create a `terraform.tfvars` file locally, and populate it with:
 ## To Do
 
 - Add environment variables to the lambda resource once known.
+- Lambda may need `vpc_config` block to access RDS.
 
 ## Provisioning Resources
 


### PR DESCRIPTION
Merges into `76-improvement-terraform-restructure`.

## Changes
- Added new ECR to `terraform/ECR/ecr.tf` for the lambda image, and updated README.
- Added the Lambda and S3 bucket to `terraform/pipeline_archived_data/pipeline_archived.tf` for the archived data pipeline, and updated README.

## Additional Notes
- I've seen it mentioned that a Lambda may need a `vpc_config` block to access an RDS. It seems like a requirement if trying to access an RDS in a private subnet, but maybe not if the RDS is on a public subnet? I've read conflicting things on this. Currently it doesn't have a 'vpc_config' block but if we deploy and it doesn't work that's a potential area to look at.

- I've given the lambda permissions to put objects in S3, but I'm not sure if I also need to give the S3 bucket a policy which also allows lambda write. I've left it out for now but if we run into issues with uploading to S3 then it's hopefully that.

Both of these issues are hard to debug without actually manually testing if it works, so let me know once we have the script ready for the archived data and we can give it a go!