### PR TITLE
83 - Added task role and execution role for ECS task definition.

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,6 +9,14 @@ All terraform files for the project are inside this folder.
 - `/pipeline_archived_data` will provision resources for the archived data pipeline.
 - `/dashboard` will provision resources for the dashboard.
 
-## Set up
+## Set Up
 
-Run terraform apply in `/ECR` first as the resources in `/pipeline_live_data`, `/pipeline_archived_data`, `/dashboard` will rely on the ECR's provisioned there.
+Order to run terraform apply:
+1. `/ECR`
+2. `/pipeline_live_data`
+3. `/pipeline_archived_data`
+4. `/dashboard`
+
+## To Do
+
+Make a bash script to run apply in all folders to create all resources.


### PR DESCRIPTION
Changed `terraform/dashboard/dashboard.tf`.

Realised that the ECS task definition for the dashboard didn't have permissions to access the S3 for archived data. Now it should (I'm really begging).

Closes #83.