### PR TITLE
94 - Create connect bash script

### DIFF
--- a/pipeline_live_data/connect.sh
+++ b/pipeline_live_data/connect.sh
@@ -1,0 +1,3 @@
+# Provided the correct credentials are in the .env, connect to the database.
+source .env
+sqlcmd -S $DB_HOST,$DB_PORT -U $DB_USER -P $DB_PASSWORD -d $DB_NAME


### PR DESCRIPTION
This will later be documented in the README as mentioned in #95.

- Created `connect.sh` that allows a local connection to the database.
  
Closes #94. 